### PR TITLE
Fixed broken email address

### DIFF
--- a/config.js
+++ b/config.js
@@ -36,7 +36,7 @@ module.exports = {
     {
       q: 'What if I get stuck?',
       a:
-        "Just [send us an email](vue@fullstack.io) and we'll be happy to help you get unstuck.",
+        "Just [send us an email](mailto:vue@fullstack.io) and we'll be happy to help you get unstuck.",
     },
     {
       q: 'Who wrote this?',


### PR DESCRIPTION
Currently the "email us" link adds a 404 link error on every Vue book page—this fixes that to enable students to email the course author.